### PR TITLE
Revert "[NT-0] fix: Account for boolean values"

### DIFF
--- a/Templates/helpers.jinja2
+++ b/Templates/helpers.jinja2
@@ -6,11 +6,9 @@
 } %}
 
 {%- macro print_type(property) -%}
-    {%- if property is boolean -%}
-        bool
-    {%- elif '$ref' in property -%}
+    {%- if property['$ref'] is defined -%}
         std::shared_ptr<{{ property['$ref'].split('/')[-1] }}>
-    {%- elif not 'type' in property -%}
+    {%- elif not property['type'] is defined -%}
         std::shared_ptr<rapidjson::Document>
     {%- elif property.type == 'integer' or property.type == 'number' -%}
         {%- if property.format in type_map -%}


### PR DESCRIPTION
This reverts commit a22f47964bd6291048a5e683512ec64fcff09720.

The reverted change does not actually resolve the issue and technically introduces a bug with certain types. This reverts that change. There will still be an issue in cases where an `object` type has valid `properties` and `additionalProperties == False`. However, the one object that was causing this issue from CHS has now been changed to no longer cause this problem. 

While the issue is not fixed, we know that with this change reverted we will fail on that type of object so we will know about it. If we do not revert this it will silently build the wrong thing. 