### PR TITLE
[OB-2931] fix: Fixes issue with nullable fields

### DIFF
--- a/Templates/dto.cpp.jinja2
+++ b/Templates/dto.cpp.jinja2
@@ -94,7 +94,7 @@ namespace csp::services::generated::{{ service_name | lower }}
                     {
                         JsonValueToType({{ property_name | pascalcase }}Value, m_{{ property_name | pascalcase }});
                     }
-                    {%- if 'nullable' not in schema or not schema.nullable %}
+                    {%- if 'nullable' not in property or not property.nullable %}
                     else
                     {
                         CSP_LOG_ERROR_MSG("Error: Non-nullable member {{ property_name }} is null!");


### PR DESCRIPTION
This fixes an issue where nullable fields were having checks done and error logs emitted when they were null. This was due to checking the nullable value on the schema rather than the specific property.