### PR TITLE
[OF-1564] feat: Add multiplayer service to interop generator

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -31,6 +31,10 @@ config: Config = {
         {
             'url': 'https://ogs-internal.magnopus-dev.cloud/mag-tracking/swagger/v1/swagger.json',
             'service': 'TrackingService'
+        },
+        {
+            'url': 'https://ogs-internal.magnopus-dev.cloud/mag-multiplayer/swagger/v1/swagger.json',
+            'service': 'MultiplayerService'
         }
     ]
 }

--- a/GenerateCHSWrapper.py
+++ b/GenerateCHSWrapper.py
@@ -85,7 +85,7 @@ def main():
         
         schemas = service['components'].get('schemas', {})
 
-        # Ensure each schema has a 'properties' field, making an empty one if not so the rendering dosen't fail.
+        # Ensure each schema has a 'properties' field, making an empty one if not so the rendering doesn't fail.
         for schema in schemas.values():
             if isinstance(schema, dict) and 'properties' not in schema:
                 schema['properties'] = {}

--- a/GenerateCHSWrapper.py
+++ b/GenerateCHSWrapper.py
@@ -82,6 +82,13 @@ def main():
 
     for service_name, service in services.items():
         os.mkdir(f"generated/Services/{ service_name }")
+        
+        schemas = service['components'].get('schemas', {})
+
+        # Ensure each schema has a 'properties' field, making an empty one if not so the rendering dosen't fail.
+        for schema in schemas.values():
+            if isinstance(schema, dict) and 'properties' not in schema:
+                schema['properties'] = {}
 
         # Render data models header
         with open(f"generated/Services/{ service_name }/Dto.h", 'w') as f:

--- a/Templates/helpers.jinja2
+++ b/Templates/helpers.jinja2
@@ -24,6 +24,8 @@
                 std::shared_ptr<{{ array['$ref'].split('/')[-1] }}>
             {%- elif array.type in type_map -%}
                 {{ type_map[array.type] }}
+            {%- elif array.format in type_map -%}
+                {{ type_map[array.format] }}
             {%- else -%}
                 /* UNSUPPORTED ARRAY TYPE {{ type_name }} */
             {%- endif -%}


### PR DESCRIPTION
Adds the multiplayer restful API's, which hadn't been exposed before.

Requires 2 fixes:

- Use the format in array type rendering, as that's neccesary for dealing with types with different representations (integer -> int32 or int64)
- Enforce a properties field, even if empty and not rendered, to avoid crashing during rendering when assumptions are made.

Tested by manually copying the output and performing a build, + manual inspection.

Output here if you care to check yourself : 
[Services.zip](https://github.com/user-attachments/files/19628840/Services.zip)
