### PR TITLE
[OF-1564] fix: convert non-string values to strings

### DIFF
--- a/Templates/api.cpp.jinja2
+++ b/Templates/api.cpp.jinja2
@@ -31,7 +31,11 @@ namespace csp::services::generated::{{ service_name | lower }} {
                     *RootUri + "{{ route_path }}",
                     {
                         {%- for parameter in method.parameters | selectattr('in', 'equalto', 'path') -%}
-                            {{ parameter.name | identifier }}{{ ',' if not loop.last }}
+                            {%- if parameter.schema.type == 'string' -%}
+                                {{ parameter.name | identifier }}
+                            {%- else -%}
+                                std::to_string({{ parameter.name | identifier }}).c_str()
+                            {%- endif -%}{{ ',' if not loop.last }}
                         {%- endfor -%}
                     }
                 );


### PR DESCRIPTION
I made a mistake in the prior PR with testing, guess i didn't copy the directory right, maybe I regenerated the project and that triggered a module refresh? Assigning the two of you again since you looked at the other changes this morning.

Anyhow, our URI types don't accept non strings, so when we do

```
Uri.SetWithParams(*RootUri + "/api/v1/objects/{id}/partial-update", int_value);
```

CSP fails to compile.

> [!NOTE]  
> You may ask, why not just make our URI handle non-string types? That's what I tried to do at first, however, because we generate `{}` to mean empty container, we can't do overload resolution based on that, because that's an ambiguous type for any container. The alternate would be to generate `std::vector<the_specific_type>{}` in those cases, but this change seems simpler than that.


Since i made the mistake rushing local testing earlier, I'm testing this one a bit more properly. You can see here, branch has been updated so the csp-services module points at this branch. You can see the submodule change in the changeset.
https://github.com/magnopus-opensource/connected-spaces-platform/pull/656