### PR TITLE
[OF-1671] feat!: promote restful service api uri version information to csp foundation

### DIFF
--- a/Templates/api.cpp.jinja2
+++ b/Templates/api.cpp.jinja2
@@ -7,6 +7,7 @@
 #include "Api.h"
 
 #include <string>
+#include <fmt/format.h>
 
 
 namespace csp::services::generated::{{ service_name | lower }} {
@@ -31,9 +32,9 @@ namespace csp::services::generated::{{ service_name | lower }} {
                 csp::web::Uri Uri;
                 Uri.SetWithParams(
                     {%- if route_path[:6] == '/api/v' -%} 
-                        (ServiceDefinition->GetURI().c_str() + std::string("/api/v") + std::to_string(ServiceDefinition->GetVersion()) + "{{ route_path[7:] }}").c_str()
+                        fmt::format("{0}/api/v{1}{2}", ServiceDefinition->GetURI().c_str(), ServiceDefinition->GetVersion(), "{{ route_path[7:] }}").c_str()
                     {%- else -%} 
-                        (ServiceDefinition->GetURI() + "{{ route_path }}").c_str()
+                        fmt::format("{0}{1}", ServiceDefinition->GetURI().c_str(), "{{ route_path }}").c_str()
                     {%- endif -%},
                     {
                         {%- for parameter in method.parameters | selectattr('in', 'equalto', 'path') -%}

--- a/Templates/api.cpp.jinja2
+++ b/Templates/api.cpp.jinja2
@@ -6,11 +6,13 @@
 
 #include "Api.h"
 
+#include <string>
+
 
 namespace csp::services::generated::{{ service_name | lower }} {
 
 {% for tag, routes in tags.items() %}
-    {{ tag }}Api::{{ tag }}Api(csp::web::WebClient* InWebClient) : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().{{ service_name }}URI)
+    {{ tag }}Api::{{ tag }}Api(csp::web::WebClient* InWebClient) : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().{{ service_name }})
     {
 
     }
@@ -22,13 +24,17 @@ namespace csp::services::generated::{{ service_name | lower }} {
 
     {% for route_path, route in routes.items() %}
         {% for method_name, method in route.items() %}
-            void {{ tag }}Api::{{ route_path | camelcase }}{{ method_name | capitalize }}(
+            void {{ tag }}Api::{%- if route_path[:6] == '/api/v' -%} {{ route_path[7:] | camelcase }} {%- else -%} {{ route_path | camelcase }} {%- endif -%}{{ method_name | capitalize }}(
                 {{ print_method_parameters(method, false) }}
             ) const
             {
                 csp::web::Uri Uri;
                 Uri.SetWithParams(
-                    *RootUri + "{{ route_path }}",
+                    {%- if route_path[:6] == '/api/v' -%} 
+                        (ServiceDefinition->GetURI().c_str() + std::string("/api/v") + std::to_string(ServiceDefinition->GetVersion()) + "{{ route_path[7:] }}").c_str()
+                    {%- else -%} 
+                        (ServiceDefinition->GetURI() + "{{ route_path }}").c_str()
+                    {%- endif -%},
                     {
                         {%- for parameter in method.parameters | selectattr('in', 'equalto', 'path') -%}
                             {%- if parameter.schema.type == 'string' -%}

--- a/Templates/api.h.jinja2
+++ b/Templates/api.h.jinja2
@@ -7,6 +7,7 @@
 #include "Web/HttpPayload.h"
 #include "Dto.h"
 
+#include <string>
 #include <optional>
 
 
@@ -38,7 +39,7 @@ namespace csp::services::generated::{{ service_name | lower }}
                 {% if method.deprecated -%}
                     [[deprecated("'{{ method_name | upper }} {{ route_path }}' is deprecated!")]]
                 {% endif -%}
-                void {{ route_path | camelcase }}{{ method_name | capitalize }}(
+                void {% if route_path[:6] == '/api/v' -%} {{ route_path[7:] | camelcase }} {%- else -%} {{ route_path | camelcase }} {%- endif -%}{{ method_name | capitalize }}(
                     {{ print_method_parameters(method) }}
                 ) const;
             {% endfor %}


### PR DESCRIPTION
This is the generator portion of the [OF-1671] Promote RESTful Service API URI version information to CSPFoundation work. 

The PR contains the following changes: 

- Removed the version information from the generated code .h/.cpp files 
- The version information is referenced from a new MCSServiceDefinition object. 
- Concatenation has been simplified using libfmt. 

> [!IMPORTANT]
>
> The change here requires additional changes in CSP as the newly generated code will need to be adopted; these changes should not be merged until both PR's are approved. 